### PR TITLE
Build native image for Linux aarch64

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -12,14 +12,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-2019]
+        os: [macOS-latest, ubuntu-latest, ubuntu-22.04, windows-2019]
         include:
-          # Replace "example" with the name your binary
           - os: macOS-latest
             uploaded_filename: sbtn-x86_64-apple-darwin
             local_path: client/target/bin/sbtn
           - os: ubuntu-latest
             uploaded_filename: sbtn-x86_64-pc-linux
+            local_path: client/target/bin/sbtn
+          - os: ubuntu-22.04
+            uploaded_filename: sbtn-aarch64-pc-linux
             local_path: client/target/bin/sbtn
           - os: windows-2019
             uploaded_filename: sbtn-x86_64-pc-win32.exe
@@ -31,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sbt/sbt
+          ref: 1.8.x
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
@@ -41,10 +44,37 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         if: ${{ matrix.os == 'windows-2019' }}
       - name: Build
+        if: ${{ matrix.uploaded_filename != 'sbtn-aarch64-pc-linux' }}
         shell: bash
         run: |
           echo $(pwd)
           sbt clean nativeImage
+      - name: Build Linux aarch64
+        if: ${{ matrix.uploaded_filename == 'sbtn-aarch64-pc-linux' }}
+        uses: uraimo/run-on-arch-action@v2.5.0
+        with:
+          arch: aarch64
+          distro: ubuntu22.04
+
+          # Speeds up builds per the run-on-arch-action README
+          githubToken: ${{ github.token }}
+
+          # The shell to run commands with in the container
+          shell: /bin/bash
+
+          # build-essential and libz-dev are required to build native images.
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y curl openjdk-8-jdk build-essential libz-dev
+            # Does not work, see https://github.com/sbt/sbt/issues/6614
+            #echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+            #curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+            #apt-get update -q && apt-get install -q -y sbt
+            # Workaround:
+            curl -Ls https://scala.jfrog.io/artifactory/debian/sbt-1.8.0.deb -o sbt-1.8.0.deb
+            apt install -y ./sbt-1.8.0.deb
+          run: |
+            sbt clean nativeImage
       - uses: actions/upload-artifact@v3
         with:
           path: ${{ matrix.local_path }}


### PR DESCRIPTION
**:warning: https://github.com/sbt/sbt/pull/7108 needs to be merged before to be able to generate the correct binary!**
(The workflows from this pull request need to re-run afterwards)
<hr>

It's not possible to cross compile with `native-image` currently, not even for a different architecture on the same OS (like x86_64 -> aarch64 in Linux; unlike gcc where you could just install `gcc-aarch64-linux-gnu`), see
* https://github.com/oracle/graal/issues/407

So that's why it is necessary to run the GraalVM on the system you want to build a binary for. So it seems the only viable workaround is to make use of https://github.com/uraimo/run-on-arch-action. That is what
* coursier is using [here](https://github.com/coursier/coursier/blob/f730535d8d9c8bdb885d353c5665a6785510cf7f/.github/workflows/ci.yml#L280-L320)
* scala-ci is using [here](https://github.com/VirtusLab/scala-cli/blob/fb207c19572f3ed9af31ea87f6ed71a92bebefe3/.github/workflows/ci.yml#L202-L236)

As a result of this PR, you can download the aarch64 artifact here in my fork already: https://github.com/mkurz/sbtn-dist/actions/runs/3825630367

Eventually, this PR is needed to fix
* https://github.com/sbt/sbt/issues/7095 and
* https://github.com/sbt/sbt/issues/6906