### PR TITLE
Build binaries for macOS on the ARM64 architecture

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,4 +8,7 @@ task:
     folder: $HOME/.sbt
   build_script: arch -arm64 ./.cirrus/publish-macos-silicon.sh
   binary_artifacts:
+    name: Binary assets
     path: "sbt/client/target/bin/sbtn"
+  env:
+    GITHUB_TOKEN: ENCRYPTED[1a9fb5ccdb681945d16d5c461d5d77ae13701992dab353f0c97b01d8d7f98e3b41b731063a9a5ba15daf10b943af5dc6]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,9 @@
-macos_arm64_task:
+task:
   name: Build sbtn for macOS ARM64
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
-
+  coursier_cache:
+    folder: $HOME/Library/Caches/Coursier/v1
+  sbt_cache:
+    folder: $HOME/.sbt
   script: arch -arm64 ./.cirrus/publish-macos-silicon.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,6 @@
+macos_arm64_task:
+  name: Build sbtn for macOS ARM64
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+
+  script: arch -arm64 ./.cirrus/publish-macos-silicon.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,4 +6,6 @@ task:
     folder: $HOME/Library/Caches/Coursier/v1
   sbt_cache:
     folder: $HOME/.sbt
-  script: arch -arm64 ./.cirrus/publish-macos-silicon.sh
+  build_script: arch -arm64 ./.cirrus/publish-macos-silicon.sh
+  binary_artifacts:
+    path: "sbt/client/target/bin/sbtn"

--- a/.cirrus/publish-macos-silicon.sh
+++ b/.cirrus/publish-macos-silicon.sh
@@ -7,3 +7,26 @@ git clone --branch try-cirrus-ci https://github.com/scalacenter/sbt.git
 cd sbt
 
 sbt clean nativeImage
+
+if [[ "$CIRRUS_RELEASE" == "" ]]; then
+  echo "Not a release. No need to deploy!"
+  exit 0
+fi
+
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+  echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
+  exit 1
+fi
+
+file_content_type="application/octet-stream"
+fpath=client/target/bin/sbtn
+name=sbtn-aarch64-apple-darwin
+
+echo "Uploading $fpath..."
+name="$(basename "$fpath")-"
+url_to_upload="https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=$name"
+curl -X POST \
+  --data-binary @$fpath \
+  --header "Authorization: token $GITHUB_TOKEN" \
+  --header "Content-Type: $file_content_type" \
+  $url_to_upload

--- a/.cirrus/publish-macos-silicon.sh
+++ b/.cirrus/publish-macos-silicon.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+brew install sbt
+
+git clone --branch try-cirrus-ci https://github.com/scalacenter/sbt.git
+
+cd sbt
+
+sbt clean nativeImage

--- a/.cirrus/publish-macos-silicon.sh
+++ b/.cirrus/publish-macos-silicon.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -ex
 
 # Branch of sbt to build
-BRANCH_TO_BUILD=try-cirrus-ci
+BRANCH_TO_BUILD=1.8.x
 
 # Set up sbt and a JDK
 brew install sbt
 
 # Clone sbt repository
-git clone --branch $BRANCH_TO_BUILD https://github.com/scalacenter/sbt.git
+git clone --branch $BRANCH_TO_BUILD https://github.com/sbt/sbt.git
 cd sbt
 
 # Build sbtn native image

--- a/.cirrus/publish-macos-silicon.sh
+++ b/.cirrus/publish-macos-silicon.sh
@@ -1,11 +1,16 @@
 #!/bin/bash -ex
 
+# Branch of sbt to build
+BRANCH_TO_BUILD=try-cirrus-ci
+
+# Set up sbt and a JDK
 brew install sbt
 
-git clone --branch try-cirrus-ci https://github.com/scalacenter/sbt.git
-
+# Clone sbt repository
+git clone --branch $BRANCH_TO_BUILD https://github.com/scalacenter/sbt.git
 cd sbt
 
+# Build sbtn native image
 sbt clean nativeImage
 
 if [[ "$CIRRUS_RELEASE" == "" ]]; then

--- a/post-tag.sh
+++ b/post-tag.sh
@@ -8,7 +8,9 @@ mkdir -p target/temp
 
 BASE_URL=https://github.com/sbt/sbtn-dist/releases/download/v${VER}
 
-MAC_URL=$BASE_URL/sbtn-x86_64-apple-darwin
+MAC_X86_64_URL=$BASE_URL/sbtn-x86_64-apple-darwin
+
+MAC_AARCH64_URL=$BASE_URL/sbtn-aarch64-apple-darwin
 
 WINDOWS_URL=$BASE_URL/sbtn-x86_64-pc-win32.exe
 
@@ -21,11 +23,13 @@ LINUX_AARCH64_URL=$BASE_URL/sbtn-aarch64-pc-linux
 # cd sbtn
 
 mkdir -p target/x86_64-apple-darwin
+mkdir -p target/aarch64-apple-darwin
 mkdir -p target/x86_64-pc-linux
 mkdir -p target/aarch64-pc-linux
 mkdir -p target/x86_64-pc-win32
 
-curl -L $MAC_URL > target/x86_64-apple-darwin/sbtn
+curl -L $MAC_X86_64_URL > target/x86_64-apple-darwin/sbtn
+curl -L $MAC_AARCH64_URL > target/aarch64-apple-darwin/sbtn
 curl -L $LINUX_X86_64_URL > target/x86_64-pc-linux/sbtn
 curl -L $LINUX_AARCH64_URL > target/aarch64-pc-linux/sbtn
 curl -L $WINDOWS_URL > target/x86_64-pc-win32/sbtn.exe
@@ -38,6 +42,13 @@ tar czvf sbtn-x86_64-apple-darwin-$VER.tar.gz sbtn
 mv sbtn-x86_64-apple-darwin-$VER.tar.gz ../
 cd ../
 gpg -u 0x642ac823 --detach-sign --armor sbtn-x86_64-apple-darwin-$VER.tar.gz
+
+cd aarch64-apple-darwin
+chmod +x sbtn
+tar czvf sbtn-aarch64-apple-darwin-$VER.tar.gz sbtn
+mv sbtn-aarch64-apple-darwin-$VER.tar.gz ../
+cd ../
+gpg -u 0x642ac823 --detach-sign --armor sbtn-aarch64-apple-darwin-$VER.tar.gz
 
 cd x86_64-pc-linux
 chmod +x sbtn


### PR DESCRIPTION
This PR shows how to set up Cirrus CI to build binaries for macOS on the ARM64 architecture.

If we merge it, we will have to also install the Cirrus CI GitHub app on the sbt/sbtn-dist repo.

I could not test the release workflow. Probably we need to cut a release from the main branch? I tried to push a tag and create a GitHub release from that but that did not trigger a build on the Cirrus CI side.

Relates to https://github.com/sbt/sbt/issues/7143.