### PR TITLE
Fix the asset uploading

### DIFF
--- a/.cirrus/publish-macos-silicon.sh
+++ b/.cirrus/publish-macos-silicon.sh
@@ -13,8 +13,8 @@ cd sbt
 # Build sbtn native image
 sbt clean nativeImage
 
-if [[ "$CIRRUS_RELEASE" == "" ]]; then
-  echo "Not a release. No need to deploy!"
+if [[ "$CIRRUS_TAG" == "" ]]; then
+  echo "No tag set. Stopping."
   exit 0
 fi
 
@@ -23,15 +23,34 @@ if [[ "$GITHUB_TOKEN" == "" ]]; then
   exit 1
 fi
 
+# Find the corresponding release in the sbt/sbt repository
+CURL_RESULT=$(curl --location --fail --silent \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN"\
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/sbt/sbt/releases/tags/$CIRRUS_TAG")
+
+if [[ "$?" -ne 0 ]]; then
+  echo "Release $CIRRUS_TAG not found in repository sbt/sbt."
+  exit 1
+fi
+
+RELEASE=$(echo $CURL_RESULT | jq '.id')
+
 file_content_type="application/octet-stream"
 fpath=client/target/bin/sbtn
 name=sbtn-aarch64-apple-darwin
 
 echo "Uploading $fpath..."
 name="$(basename "$fpath")-"
-url_to_upload="https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=$name"
+url_to_upload="https://uploads.github.com/repos/sbt/sbt/releases/$RELEASE/assets?name=$name"
 curl -X POST \
   --data-binary @$fpath \
-  --header "Authorization: token $GITHUB_TOKEN" \
+  --header "Authorization: Bearer $GITHUB_TOKEN" \
   --header "Content-Type: $file_content_type" \
   $url_to_upload
+
+if [[ "$?" -ne 0 ]]; then
+  echo "Asset upload failed."
+  exit 1
+fi


### PR DESCRIPTION
We used to try to upload the binaries to a release defined in the current (sbt/sbtn-dist) repository, which failed because the releases are defined in the sbt/sbt repo.

We fix that by fetching the sbt/sbt release that matches the tag that triggered the build and we upload to that release.