### PR TITLE
Bump sbt version to 1.10.4 & add build.properties

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -195,7 +195,7 @@ jobs:
             apt-get install -q -y curl openjdk-8-jdk build-essential libz-dev
             # Install sbt inside the docker image
             mkdir -p "$HOME/bin/"
-            curl -sL https://raw.githubusercontent.com/sbt/sbt/v1.9.9/sbt > "$HOME/bin/sbt"
+            curl -sL https://raw.githubusercontent.com/sbt/sbt/v1.10.4/sbt > "$HOME/bin/sbt"
             chmod +x "$HOME/bin/sbt"
           run: |
             # Use sbt inside the Docker image

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.4


### PR DESCRIPTION
This PR
- Bumps sbt version to 1.10.4
- Ports https://github.com/sbt/setup-sbt/pull/14 so scala steward can take over sbt version bumps.